### PR TITLE
chore(release): pulling release/1.2.1 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.2.1](https://github.com/rudderlabs/metrics-reporter-ios/compare/v1.2.0...v1.2.1) (2024-01-03)
+
 ## [1.2.0](https://github.com/rudderlabs/metrics-reporter-ios/compare/v1.1.1...v1.2.0) (2023-12-20)
 
 

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "RudderKit", url: "https://github.com/rudderlabs/rudder-ios-kit", from: "1.4.0"),
-        .package(name: "RSCrashReporter", url: "https://github.com/rudderlabs/crash-reporter-ios", from: "1.0.0"),
+        .package(name: "RSCrashReporter", url: "https://github.com/rudderlabs/crash-reporter-ios", from: "1.0.1"),
     ],
     targets: [
         .target(

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_metrics-reporter-ios
 sonar.organization=rudderlabs
 sonar.projectName=Metrics Reporter iOS
-sonar.projectVersion=1.2.0
+sonar.projectVersion=1.2.1
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/metrics-reporter-ios


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2024-01-03)<br> * chore: update version of RSCrashReporter in Package.swift ([f61db61](https://github.com/rudderlabs/metrics-reporter-ios/commit/f61db61))