### PR TITLE
chore(release): pulling release/1.2.2 into master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: 'Tests & Coverage'
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:
@@ -22,7 +22,7 @@ jobs:
         
       - name: Install xcpretty
         run: gem install xcpretty
-
+        
       - name: Install Cocoapods
         run: gem install cocoapods
         
@@ -55,7 +55,4 @@ jobs:
         run: |
           sonar-scanner -Dsonar.host.url=https://sonarcloud.io
         
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.2.2](https://github.com/rudderlabs/metrics-reporter-ios/compare/v1.2.1...v1.2.2) (2024-08-29)
+
 ### [1.2.1](https://github.com/rudderlabs/metrics-reporter-ios/compare/v1.2.0...v1.2.1) (2024-01-03)
 
 ## [1.2.0](https://github.com/rudderlabs/metrics-reporter-ios/compare/v1.1.1...v1.2.0) (2023-12-20)

--- a/Examples/SampleObjC/SampleObjC/AppDelegate.m
+++ b/Examples/SampleObjC/SampleObjC/AppDelegate.m
@@ -19,8 +19,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.
-    
-    RSMetricConfiguration *config = [[RSMetricConfiguration alloc] initWithLogLevel:RudderLogLevelVerbose writeKey:@"WRITE_KEY" sdkVersion:@"1.1.1"];
+    RSMetricConfiguration *config = [[RSMetricConfiguration alloc] initWithLogLevel:RudderLogLevelVerbose writeKey:@"WRITE_KEY" sdkVersion:@"1.1.1" sdkMetricsUrl:@"SDK_Metrics_Url"];
     RSMetricsClient *client = [[RSMetricsClient alloc] initWithConfiguration:config];
     
     RSCount *count = [[RSCount alloc] initWithName:@"test_count" labels:@{@"key_1": @"value_1"} value:10];

--- a/Examples/SampleSwift/SampleSwift/AppDelegate.swift
+++ b/Examples/SampleSwift/SampleSwift/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        let configuration = Configuration(logLevel: .debug, writeKey: "WRITE_KEY", sdkVersion: "1.3.3", maxMetricsInBatch: 1, flushInterval: 1)
+        let configuration = Configuration(logLevel: .debug, writeKey: "WRITE_KEY", sdkVersion: "1.3.3", sdkMetricsUrl: "SDK_Metrics_Url", maxMetricsInBatch: 1, flushInterval: 1)
         client = MetricsClient(configuration: configuration)
         client?.isMetricsCollectionEnabled = true
         client?.isErrorsCollectionEnabled = true

--- a/MetricsReporterTests/ErrorOperatorTests.swift
+++ b/MetricsReporterTests/ErrorOperatorTests.swift
@@ -51,7 +51,7 @@ final class ErrorOperatorTests: XCTestCase {
     
     func test_toDict() {
         let errorEntity = ErrorEntity(id: 1, events: createErrorEvent(index: 0))
-        let metricConfiguration = Configuration(logLevel: .none, writeKey: "WRITE_KEY", sdkVersion: "some.version")
+        let metricConfiguration = Configuration(logLevel: .none, writeKey: "WRITE_KEY", sdkVersion: "some.version", sdkMetricsUrl: "sdk.metrics.url")
         let errorsDict = [errorEntity].toDict(configuration: metricConfiguration)
         let expectedErrorsDict: [String: Any] = [
             "payloadVersion": "5",

--- a/MetricsReporterTests/MetricsClientTests.swift
+++ b/MetricsReporterTests/MetricsClientTests.swift
@@ -11,14 +11,14 @@ import XCTest
 final class MetricsClientTests: XCTestCase {
     
     func test_MetricsClient() {
-        let configuration = Configuration(logLevel: .none, writeKey: "WRITE_KEY", sdkVersion: "some.version")
+        let configuration = Configuration(logLevel: .none, writeKey: "WRITE_KEY", sdkVersion: "some.version", sdkMetricsUrl: "sdk.metrics.url")
         let client = MetricsClient(configuration: configuration)
         
         XCTAssertNotNil(client)
     }
     
     func test_Count() {
-        let configuration = Configuration(logLevel: .none, writeKey: "WRITE_KEY", sdkVersion: "some.version")
+        let configuration = Configuration(logLevel: .none, writeKey: "WRITE_KEY", sdkVersion: "some.version", sdkMetricsUrl: "sdk.metrics.url")
         let client = MetricsClient(configuration: configuration)
         client.isMetricsCollectionEnabled = true
         
@@ -36,7 +36,7 @@ final class MetricsClientTests: XCTestCase {
     }
     
     func test_Gauge() {
-        let configuration = Configuration(logLevel: .none, writeKey: "WRITE_KEY", sdkVersion: "some.version")
+        let configuration = Configuration(logLevel: .none, writeKey: "WRITE_KEY", sdkVersion: "some.version", sdkMetricsUrl: "sdk.metrics.url")
         let client = MetricsClient(configuration: configuration)
         client.isMetricsCollectionEnabled = true
         
@@ -54,7 +54,7 @@ final class MetricsClientTests: XCTestCase {
     }
     
     func test_StatsCollection() {
-        let configuration = Configuration(logLevel: .none, writeKey: "WRITE_KEY", sdkVersion: "some.version")
+        let configuration = Configuration(logLevel: .none, writeKey: "WRITE_KEY", sdkVersion: "some.version", sdkMetricsUrl: "sdk.metrics.url")
         let client = MetricsClient(configuration: configuration)
         
         XCTAssertFalse(client.isErrorsCollectionEnabled)

--- a/MetricsReporterTests/MetricsUploaderTests.swift
+++ b/MetricsReporterTests/MetricsUploaderTests.swift
@@ -17,7 +17,7 @@ final class MetricsUploaderTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        let metricConfiguration = Configuration(logLevel: .none, writeKey: "WRITE_KEY", sdkVersion: "some.version", maxErrorsInBatch: 1, maxMetricsInBatch: 1, flushInterval: 1)
+        let metricConfiguration = Configuration(logLevel: .none, writeKey: "WRITE_KEY", sdkVersion: "some.version", sdkMetricsUrl: "sdk.metrics.url", maxErrorsInBatch: 1, maxMetricsInBatch: 1, flushInterval: 1)
         database = {
             let db = openDatabase()
             return Database(database: db)

--- a/MetricsReporterTests/ObjCTests.swift
+++ b/MetricsReporterTests/ObjCTests.swift
@@ -11,14 +11,13 @@ import XCTest
 final class ObjCTests: XCTestCase {
 
     func test_ObjCConfiguration() {
-        let configuration = ObjCConfiguration(logLevel: 0, writeKey: "WRITE_KEY", sdkVersion: "some.version")
+        let configuration = ObjCConfiguration(logLevel: 0, writeKey: "WRITE_KEY", sdkVersion: "some.version", sdkMetricsUrl: "sdk.metrics.url")
         
         XCTAssertEqual(configuration.configuration.logLevel, .none)
         XCTAssertEqual(configuration.configuration.writeKey, "WRITE_KEY")
         XCTAssertEqual(configuration.configuration.sdkVersion, "some.version")
         
-        let configuration2 = ObjCConfiguration(logLevel: 1, writeKey: "WRITE_KEY_2", sdkVersion: "some.version.2")
-            .sdkMetricsUrl("some.url.com")
+        let configuration2 = ObjCConfiguration(logLevel: 1, writeKey: "WRITE_KEY_2", sdkVersion: "some.version.2", sdkMetricsUrl: "some.url.com")
             .maxErrorsInBatch(11)
             .maxMetricsInBatch(13)
             .flushInterval(7)
@@ -98,14 +97,14 @@ final class ObjCTests: XCTestCase {
     }
     
     func test_ObjCMetricsClient() {
-        let configuration = ObjCConfiguration(logLevel: 0, writeKey: "WRITE_KEY", sdkVersion: "some.version")
+        let configuration = ObjCConfiguration(logLevel: 0, writeKey: "WRITE_KEY", sdkVersion: "some.version", sdkMetricsUrl: "sdk.metrics.url")
         let client = ObjCMetricsClient(configuration: configuration)
         
         XCTAssertNotNil(client)
     }
     
     func test_StatsCollection() {
-        let configuration = ObjCConfiguration(logLevel: 0, writeKey: "WRITE_KEY", sdkVersion: "some.version")
+        let configuration = ObjCConfiguration(logLevel: 0, writeKey: "WRITE_KEY", sdkVersion: "some.version", sdkMetricsUrl: "sdk.metrics.url")
         let client = ObjCMetricsClient(configuration: configuration)
         
         XCTAssertFalse(client.isErrorsCollectionEnabled)

--- a/MetricsReporterTests/ServiceManagerTests.swift
+++ b/MetricsReporterTests/ServiceManagerTests.swift
@@ -19,7 +19,7 @@ final class ServiceManagerTests: XCTestCase {
         configuration.protocolClasses = [MockURLProtocol.self]
         let urlSession = URLSession.init(configuration: configuration)
         
-        serviceManager = ServiceManager(urlSession: urlSession, configuration: Configuration(logLevel: .none, writeKey: "WRITE_KEY", sdkVersion: "some.version"))
+        serviceManager = ServiceManager(urlSession: urlSession, configuration: Configuration(logLevel: .none, writeKey: "WRITE_KEY", sdkVersion: "some.version", sdkMetricsUrl: "sdk.metrics.url"))
         promise = expectation(description: "Expectation")
     }
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MetricsReporter (1.1.1):
+  - MetricsReporter (1.2.1):
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
@@ -20,10 +20,10 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  MetricsReporter: d0ad4a52c6ae245b71190b632e89c547d05ae2d5
+  MetricsReporter: 99596ee5003c69949ed2f50acc34aee83c42f843
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
 
 PODFILE CHECKSUM: 4a55181dcf11068d481028b936d656938169e63a
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.15.2

--- a/Sources/Classes/Constants.swift
+++ b/Sources/Classes/Constants.swift
@@ -9,7 +9,6 @@ import Foundation
 
 struct Constants {
     struct Config {
-        static let SDKMETRICS_URL = "https://sdk-metrics.rudderstack.com"
         static let MAX_METRICS_IN_A_BATCH = 10
         static let MAX_ERRORS_IN_A_BATCH = 5
         static let FLUSH_INTERVAL = 30

--- a/Sources/Classes/Models/Configuration.swift
+++ b/Sources/Classes/Models/Configuration.swift
@@ -18,11 +18,11 @@ public struct Configuration {
     var flushInterval: Int
     var dbCountThreshold: Int
     
-    public init(logLevel: LogLevel, writeKey: String, sdkVersion: String, sdkMetricsUrl: String? = nil, maxErrorsInBatch: Int? = nil, maxMetricsInBatch: Int? = nil, flushInterval: Int? = nil, dbCountThreshold: Int? = nil) {
+    public init(logLevel: LogLevel, writeKey: String, sdkVersion: String, sdkMetricsUrl: String, maxErrorsInBatch: Int? = nil, maxMetricsInBatch: Int? = nil, flushInterval: Int? = nil, dbCountThreshold: Int? = nil) {
         self.logLevel = logLevel
         self.writeKey = writeKey
         self.sdkVersion = sdkVersion
-        self.sdkMetricsUrl = sdkMetricsUrl ?? Constants.Config.SDKMETRICS_URL
+        self.sdkMetricsUrl = sdkMetricsUrl
         self.maxErrorsInBatch = maxErrorsInBatch ?? Constants.Config.MAX_ERRORS_IN_A_BATCH
         self.maxMetricsInBatch = maxMetricsInBatch ?? Constants.Config.MAX_METRICS_IN_A_BATCH
         self.flushInterval = flushInterval ?? Constants.Config.FLUSH_INTERVAL

--- a/Sources/Classes/Networking/APIClient/ServiceManager.swift
+++ b/Sources/Classes/Networking/APIClient/ServiceManager.swift
@@ -124,7 +124,7 @@ extension ServiceManager {
     func path(_ api: API) -> String {
         switch api {
         case .sdkMetrics:
-            return "/sdkmetrics"
+            return "rsaMetrics"
         }
     }
 }

--- a/Sources/Classes/ObjC/ObjCConfiguration.swift
+++ b/Sources/Classes/ObjC/ObjCConfiguration.swift
@@ -13,14 +13,8 @@ public class ObjCConfiguration: NSObject {
     var configuration: Configuration
     
     @objc
-    public init(logLevel: Int, writeKey: String, sdkVersion: String) {
-        configuration = Configuration(logLevel: LogLevel(rawValue: logLevel) ?? .error, writeKey: writeKey, sdkVersion: sdkVersion)
-    }
-    
-    @discardableResult @objc
-    public func sdkMetricsUrl(_ sdkMetricsUrl: String) -> ObjCConfiguration {
-        configuration.sdkMetricsUrl = sdkMetricsUrl
-        return self
+    public init(logLevel: Int, writeKey: String, sdkVersion: String, sdkMetricsUrl: String) {
+        configuration = Configuration(logLevel: LogLevel(rawValue: logLevel) ?? .error, writeKey: writeKey, sdkVersion: sdkVersion, sdkMetricsUrl: sdkMetricsUrl)
     }
     
     @discardableResult @objc

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_metrics-reporter-ios
 sonar.organization=rudderlabs
 sonar.projectName=Metrics Reporter iOS
-sonar.projectVersion=1.2.1
+sonar.projectVersion=1.2.2
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/metrics-reporter-ios


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2024-08-29)<br> *  feat: change the existing constant url to receiving url from sdk initialization ( 44) ([30633f2](https://github.com/rudderlabs/metrics-reporter-ios/commit/30633f2)), closes [ 44](https://github.com/rudderlabs/metrics-reporter-ios/issues/44)<br> * Updated license to ELv2 ([d5f8636](https://github.com/rudderlabs/metrics-reporter-ios/commit/d5f8636))<br> * docs: update and rename LICENSE to LICENSE.md ([bc49c0a](https://github.com/rudderlabs/metrics-reporter-ios/commit/bc49c0a))