### PR TITLE
chore(release): pulling release/2.0.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.0.0](https://github.com/rudderlabs/metrics-reporter-ios/compare/v1.3.0...v2.0.0) (2024-09-03)
+
+
+### ⚠ BREAKING CHANGES
+
+* Updated the existing constant URL
+
+### Features
+
+* change the existing constant url to receiving url from sdk initialisation ([6e2f97e](https://github.com/rudderlabs/metrics-reporter-ios/commit/6e2f97e601c0bfa2532613449a9b42f32cc7d7e8))
+
 ### [1.3.0](https://github.com/rudderlabs/metrics-reporter-ios/compare/v1.2.1...v1.3.0) (2024-08-29)
 
 ### [1.2.1](https://github.com/rudderlabs/metrics-reporter-ios/compare/v1.2.0...v1.2.1) (2024-01-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [2.0.0](https://github.com/rudderlabs/metrics-reporter-ios/compare/v1.3.0...v2.0.0) (2024-09-03)
+## [2.0.0](https://github.com/rudderlabs/metrics-reporter-ios/compare/v1.2.1...v2.0.0) (2024-09-03)
 
 
 ### ⚠ BREAKING CHANGES
 
-* Updated the existing constant URL
+* Removal of the existing constant metrics URL
 
 ### Features
 
 * change the existing constant url to receiving url from sdk initialisation ([6e2f97e](https://github.com/rudderlabs/metrics-reporter-ios/commit/6e2f97e601c0bfa2532613449a9b42f32cc7d7e8))
-
-### [1.3.0](https://github.com/rudderlabs/metrics-reporter-ios/compare/v1.2.1...v1.3.0) (2024-08-29)
 
 ### [1.2.1](https://github.com/rudderlabs/metrics-reporter-ios/compare/v1.2.0...v1.2.1) (2024-01-03)
 

--- a/Examples/SampleSwift/SampleSwift/AppDelegate.swift
+++ b/Examples/SampleSwift/SampleSwift/AppDelegate.swift
@@ -26,6 +26,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             client?.process(metric: countMetric)
         }
         
+        
         return true
     }
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.3.0",
+    "version": "2.0.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_metrics-reporter-ios
 sonar.organization=rudderlabs
 sonar.projectName=Metrics Reporter iOS
-sonar.projectVersion=1.3.0
+sonar.projectVersion=2.0.0
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/metrics-reporter-ios


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2024-09-03)<br> * feat!: change the existing constant url to receiving url from sdk initialisation ([6e2f97e](https://github.com/rudderlabs/metrics-reporter-ios/commit/6e2f97e))    BREAKING CHANGE<br> * Updated the existing constant URL